### PR TITLE
Updated tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noLib": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "esModuleInterop": true,
     "sourceMap": false,
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
Added `esModuleInterop` for ESModule to commonjs module. Fixed web3_1.default error.

Tried to solve [Issue 1](https://github.com/owl1n/nestjs-web3/issues/1)